### PR TITLE
Implement small scale quantiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(EXTENSION_SOURCES
     src/operation_latency_histogram.cpp
     src/quantile.cpp
     src/quantilelite.cpp
+    src/quantile_estimator.cpp
     src/string_utils.cpp
     src/time_utils.cpp
     duckdb-httpfs/extension/httpfs/create_secret_functions.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(EXTENSION_SOURCES
     src/observability_filesystem.cpp
     src/operation_latency_histogram.cpp
     src/quantile.cpp
+    src/quantilelite.cpp
     src/string_utils.cpp
     src/time_utils.cpp
     duckdb-httpfs/extension/httpfs/create_secret_functions.cpp

--- a/src/include/quantile.hpp
+++ b/src/include/quantile.hpp
@@ -1,9 +1,13 @@
+// This class is used to get quantile data for large scale data points via P2 algorithm.
+//
+// It's NOT thread-safe.
+
 #pragma once
 
-#include <iostream>
-#include <vector>
 #include <array>
 #include <algorithm>
+
+#include "duckdb/common/vector.hpp"
 
 namespace duckdb {
 
@@ -12,44 +16,40 @@ public:
     explicit P2Quantile(double quantile) : q(quantile), n(0) {
         markers.fill({0.0, 0});
         desired.fill(0.0);
-        q_probs = {0.0, q/2.0, q, (1.0+q)/2.0, 1.0};
+        q_probs = {0.0, q / 2.0, q, (1.0 + q) / 2.0, 1.0};
     }
 
     // Add the given value to quantile.
-    void Add(double x);
+    void Add(float x);
+
+    // Bulk ingest data points to quantile.
+    void BulkAdd(vector<float> data_points);
 
     // Return the current quantile estimate.
     //
-    // If fewer than 5 samples have been observed (`n < 5`), the estimator is still in its initialization phase. In that case we simply return
-    // the median of the values collected so far (approximated as buffer[n/2]) instead of using the P² algorithm.
-    //
-    // Once 5 or more samples are available, the P² algorithm is active. In this case the quantile estimate is always represented by the
-    // 3rd marker (markers[2]), which the algorithm maintains as an approximation of the target quantile (p50, p75, p90, etc., depending
-    // on the instance).
-    double get() const {
-        return (n < 5) ? buffer[n/2] : markers[2].height;
+    // Quantile estimate is always represented by the 3rd marker (markers[2]), which the algorithm maintains as an
+    // approximation of the target quantile (p50, p75, p90, etc., depending on the instance).
+    float Get() const {
+        return markers[2].height;
     }
 
 private:
     struct Marker {
-        double height;
+        float height;
         int pos;
     };
 
     // P50, P75, P90, P95, P99
     inline static constexpr size_t QUANTILE_COUNT = 5;
-    double q = 0;
+    float q = 0;
     int n = 0;
     std::array<Marker, QUANTILE_COUNT> markers;
-    std::array<double, QUANTILE_COUNT> desired;
-    std::array<double, QUANTILE_COUNT> buffer;
+    std::array<float, QUANTILE_COUNT> desired;
     std::array<double, QUANTILE_COUNT> q_probs;
 
-    void Init();
+    float Parabolic(int i, int s) const;
 
-    double Parabolic(int i, int s) const;
-
-    double Linear(int i, int s) const;
+    float Linear(int i, int s) const;
 };
 
 }  // namespace duckdb

--- a/src/include/quantile_estimator.hpp
+++ b/src/include/quantile_estimator.hpp
@@ -1,30 +1,100 @@
 #pragma once
 
 #include <array>
-#include <vector>
+#include <mutex>
 
+#include "duckdb/common/vector.hpp"
 #include "quantile.hpp"
+#include "quantilelite.hpp"
 
 namespace duckdb {
 
 class QuantileEstimator {
 public:
-    QuantileEstimator() {
+    QuantileEstimator() = default;
+    ~QuantileEstimator() = default;
+
+    void Add(float x) {
+        std::lock_guard<std::mutex> lck(mu);
+        if (!estimators.empty()) {
+            for (auto& e : estimators) {
+                e.Add(x); 
+            }
+            return;
+        }
+
+        // If inline memory storage reaches threshold, switch to stats based method.
+        if (quantile_lite.GetNumCollected() >= LARGE_SCALE_DATA_POINT_THRESHOLD) {
+            InitializeP2QuantileWithLock();
+            for (auto& e : estimators) {
+                e.Add(x); 
+            }
+            return;
+        }
+        
+        // Fallback to in-memory storage.
+        quantile_lite.Add(x);
+    }
+
+    float p50() {
+        std::lock_guard<std::mutex> lck(mu);
+        if (estimators.empty()) {
+            return quantile_lite.p50();
+        }
+        return estimators[0].Get(); 
+    }
+    float p75() {
+        std::lock_guard<std::mutex> lck(mu);
+        if (estimators.empty()) {
+            return quantile_lite.p75();
+        }
+        return estimators[1].Get(); 
+    }
+    float p90() {
+        std::lock_guard<std::mutex> lck(mu);
+        if (estimators.empty()) {
+            return quantile_lite.p90();
+        }
+        return estimators[2].Get(); 
+    }
+    float p95() {
+        std::lock_guard<std::mutex> lck(mu);
+        if (estimators.empty()) {
+            return quantile_lite.p95();
+        }
+        return estimators[3].Get(); 
+    }
+    float p99() {
+        std::lock_guard<std::mutex> lck(mu);
+        if (estimators.empty()) {
+            return quantile_lite.p99();
+        }
+        return estimators[4].Get(); 
+    }
+
+private:
+    // Initialize P2 quantile.
+    void InitializeP2QuantileWithLock() {
+        D_ASSERT(estimators.empty());
         constexpr std::array<double, 5> QUANTILES {0.50, 0.75, 0.90, 0.95, 0.99};
         estimators.reserve(QUANTILES.size());
         for (double q : QUANTILES) {
             estimators.emplace_back(q);
         }
-    }
-    void Add(double x) { for (auto& e : estimators) e.Add(x); }
-    double p50() const { return estimators[0].get(); }
-    double p75() const { return estimators[1].get(); }
-    double p90() const { return estimators[2].get(); }
-    double p95() const { return estimators[3].get(); }
-    double p99() const { return estimators[4].get(); }
 
-private:
-    std::vector<P2Quantile> estimators;
+        auto data_points = quantile_lite.Extract();
+        for (auto& e : estimators) {
+            e.BulkAdd(data_points);
+        }
+    }
+
+    // Used to trigger large-scale data point ingestion.
+    inline static constexpr size_t LARGE_SCALE_DATA_POINT_THRESHOLD = 512;
+    mutable std::mutex mu;
+    // Used for small scale data points, where P² algorithm doesn't work well and memory footprint is acceptable.
+    QuantileLite quantile_lite;
+    // Used for large scale data points, where P² algorithm generates precise-enough quantile result.
+    vector<P2Quantile> estimators;
 };
 
 } // namespace duckdb

--- a/src/include/quantile_estimator.hpp
+++ b/src/include/quantile_estimator.hpp
@@ -14,79 +14,18 @@ public:
     QuantileEstimator() = default;
     ~QuantileEstimator() = default;
 
-    void Add(float x) {
-        std::lock_guard<std::mutex> lck(mu);
-        if (!estimators.empty()) {
-            for (auto& e : estimators) {
-                e.Add(x); 
-            }
-            return;
-        }
+    // Add the given value to quantile calculator.
+    void Add(float x);
 
-        // If inline memory storage reaches threshold, switch to stats based method.
-        if (quantile_lite.GetNumCollected() >= LARGE_SCALE_DATA_POINT_THRESHOLD) {
-            InitializeP2QuantileWithLock();
-            for (auto& e : estimators) {
-                e.Add(x); 
-            }
-            return;
-        }
-        
-        // Fallback to in-memory storage.
-        quantile_lite.Add(x);
-    }
-
-    float p50() {
-        std::lock_guard<std::mutex> lck(mu);
-        if (estimators.empty()) {
-            return quantile_lite.p50();
-        }
-        return estimators[0].Get(); 
-    }
-    float p75() {
-        std::lock_guard<std::mutex> lck(mu);
-        if (estimators.empty()) {
-            return quantile_lite.p75();
-        }
-        return estimators[1].Get(); 
-    }
-    float p90() {
-        std::lock_guard<std::mutex> lck(mu);
-        if (estimators.empty()) {
-            return quantile_lite.p90();
-        }
-        return estimators[2].Get(); 
-    }
-    float p95() {
-        std::lock_guard<std::mutex> lck(mu);
-        if (estimators.empty()) {
-            return quantile_lite.p95();
-        }
-        return estimators[3].Get(); 
-    }
-    float p99() {
-        std::lock_guard<std::mutex> lck(mu);
-        if (estimators.empty()) {
-            return quantile_lite.p99();
-        }
-        return estimators[4].Get(); 
-    }
+    float p50();
+    float p75();
+    float p90();
+    float p95();
+    float p99();
 
 private:
     // Initialize P2 quantile.
-    void InitializeP2QuantileWithLock() {
-        D_ASSERT(estimators.empty());
-        constexpr std::array<double, 5> QUANTILES {0.50, 0.75, 0.90, 0.95, 0.99};
-        estimators.reserve(QUANTILES.size());
-        for (double q : QUANTILES) {
-            estimators.emplace_back(q);
-        }
-
-        auto data_points = quantile_lite.Extract();
-        for (auto& e : estimators) {
-            e.BulkAdd(data_points);
-        }
-    }
+    void InitializeP2QuantileWithLock();
 
     // Used to trigger large-scale data point ingestion.
     inline static constexpr size_t LARGE_SCALE_DATA_POINT_THRESHOLD = 512;

--- a/src/include/quantilelite.hpp
+++ b/src/include/quantilelite.hpp
@@ -1,0 +1,54 @@
+// This class is used to get quantile data for small scale data points.
+//
+// It's NOT thread-safe.
+
+#pragma once
+
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+class QuantileLite {
+public:
+    QuantileLite() = default;
+    ~QuantileLite() = default;
+
+    void Add(float x) {
+        samples.push_back(x);
+    }
+
+    // Extract all data points out.
+    vector<float> Extract() {
+        auto extracted = std::move(samples);
+        samples.clear();
+        return extracted;
+    }
+
+    // Get number of data points already collected.
+    size_t GetNumCollected() const {
+        return samples.size();
+    }
+
+    float p50() {
+        return Quantile(0.50); 
+    }
+    float p75() {
+        return Quantile(0.75); 
+    }
+    float p90() {
+        return Quantile(0.90); 
+    }
+    float p95() {
+        return Quantile(0.95); 
+    }
+    float p99() {
+        return Quantile(0.99); 
+    }
+
+private:
+    float Quantile(float q);
+
+    vector<float> samples;
+};
+
+}  // namespace duckdb

--- a/src/quantile.cpp
+++ b/src/quantile.cpp
@@ -2,62 +2,63 @@
 
 namespace duckdb {
 
-void P2Quantile::Add(double x) {
-    if (n < 5) {
-        buffer[n++] = x;
-        if (n == 5) {
-            Init();
-        }
-        return;
+void P2Quantile::Add(float x) {
+    int k = 0;
+    if (x < markers[0].height) { 
+        markers[0].height = x; 
+        k = 0; 
+    }
+    else if (x < markers[1].height) { 
+        k = 0; 
+    }
+    else if (x < markers[2].height) { 
+        k = 1; 
+    }
+    else if (x < markers[3].height) { 
+        k = 2; 
+    }
+    else if (x < markers[4].height) { 
+        k = 3; 
+    }
+    else { 
+        markers[4].height = x; 
+        k = 3;
     }
 
-    // Find k.
-    int k = 0;
-    if (x < markers[0].height) { markers[0].height = x; k = 0; }
-    else if (x < markers[1].height) { k = 0; }
-    else if (x < markers[2].height) { k = 1; }
-    else if (x < markers[3].height) { k = 2; }
-    else if (x < markers[4].height) { k = 3; }
-    else { markers[4].height = x; k = 3; }
-
-    for (int i = k+1; i < 5; i++) {
-        markers[i].pos++;
+    for (int ii = k + 1; ii < 5; ++ii) {
+        markers[ii].pos++;
     }
 
     // Update desired positions.
-    for (int i = 0; i < 5; i++)
-        desired[i] = 1 + (n - 1) * q_probs[i];
+    for (int ii = 0; ii < 5; ++ii)
+        desired[ii] = 1 + (n - 1) * q_probs[ii];
 
     // Adjust markers.
-    for (int i = 1; i < 4; i++) {
-        double d = desired[i] - markers[i].pos;
-        if ((d >= 1 && markers[i+1].pos - markers[i].pos > 1) ||
-            (d <= -1 && markers[i-1].pos - markers[i].pos < -1)) {
+    for (int ii = 1; ii < 4; ++ii) {
+        double d = desired[ii] - markers[ii].pos;
+        if ((d >= 1 && markers[ii + 1].pos - markers[ii].pos > 1) ||
+            (d <= -1 && markers[ii - 1].pos - markers[ii].pos < -1)) {
             int s = (d >= 0) ? 1 : -1;
-            double newH = Parabolic(i, s);
-            if (markers[i-1].height < newH && newH < markers[i+1].height) {
-                markers[i].height = newH;
+            double newH = Parabolic(ii, s);
+            if (markers[ii - 1].height < newH && newH < markers[ii + 1].height) {
+                markers[ii].height = newH;
             }
             else {
-                markers[i].height = Linear(i, s);
+                markers[ii].height = Linear(ii, s);
             }
-            markers[i].pos += s;
+            markers[ii].pos += s;
         }
     }
     n++;
 }
 
-void P2Quantile::Init() {
-    std::sort(buffer.begin(), buffer.begin() + 5);
-    for (int i = 0; i < 5; i++) {
-        markers[i] = {buffer[i], i+1};
-    }
-    for (int i = 0; i < 5; i++) {
-        desired[i] = 1 + (n - 1) * q_probs[i];
+void P2Quantile::BulkAdd(vector<float> data_points) {
+    for (float cur_data : data_points) {
+        Add(cur_data);
     }
 }
 
-double P2Quantile::Parabolic(int i, int s) const {
+float P2Quantile::Parabolic(int i, int s) const {
     double m1 = markers[i-1].pos, m = markers[i].pos, m2 = markers[i+1].pos;
     double q1 = markers[i-1].height, q_ = markers[i].height, q2 = markers[i+1].height;
     return q_ + s / (m2 - m1) *
@@ -65,7 +66,7 @@ double P2Quantile::Parabolic(int i, int s) const {
             (m2 - m - s) * (q_ - q1) / (m - m1));
 }
 
-double P2Quantile::Linear(int i, int s) const {
+float P2Quantile::Linear(int i, int s) const {
     return markers[i].height + s *
         (markers[i+s].height - markers[i].height) /
         (markers[i+s].pos - markers[i].pos);

--- a/src/quantile_estimator.cpp
+++ b/src/quantile_estimator.cpp
@@ -1,0 +1,77 @@
+#include "quantile_estimator.hpp"
+
+namespace duckdb {
+
+void QuantileEstimator::Add(float x) {
+    std::lock_guard<std::mutex> lck(mu);
+    if (!estimators.empty()) {
+        for (auto& e : estimators) {
+            e.Add(x); 
+        }
+        return;
+    }
+
+    // If inline memory storage reaches threshold, switch to stats based method.
+    if (quantile_lite.GetNumCollected() >= LARGE_SCALE_DATA_POINT_THRESHOLD) {
+        InitializeP2QuantileWithLock();
+        for (auto& e : estimators) {
+            e.Add(x); 
+        }
+        return;
+    }
+    
+    // Fallback to in-memory storage.
+    quantile_lite.Add(x);
+}
+
+float QuantileEstimator::p50() {
+    std::lock_guard<std::mutex> lck(mu);
+    if (estimators.empty()) {
+        return quantile_lite.p50();
+    }
+    return estimators[0].Get(); 
+}
+float QuantileEstimator::p75() {
+    std::lock_guard<std::mutex> lck(mu);
+    if (estimators.empty()) {
+        return quantile_lite.p75();
+    }
+    return estimators[1].Get(); 
+}
+float QuantileEstimator::p90() {
+    std::lock_guard<std::mutex> lck(mu);
+    if (estimators.empty()) {
+        return quantile_lite.p90();
+    }
+    return estimators[2].Get(); 
+}
+float QuantileEstimator::p95() {
+    std::lock_guard<std::mutex> lck(mu);
+    if (estimators.empty()) {
+        return quantile_lite.p95();
+    }
+    return estimators[3].Get(); 
+}
+float QuantileEstimator::p99() {
+    std::lock_guard<std::mutex> lck(mu);
+    if (estimators.empty()) {
+        return quantile_lite.p99();
+    }
+    return estimators[4].Get(); 
+}
+
+void QuantileEstimator::InitializeP2QuantileWithLock() {
+    D_ASSERT(estimators.empty());
+    constexpr std::array<double, 5> QUANTILES {0.50, 0.75, 0.90, 0.95, 0.99};
+    estimators.reserve(QUANTILES.size());
+    for (double q : QUANTILES) {
+        estimators.emplace_back(q);
+    }
+
+    auto data_points = quantile_lite.Extract();
+    for (auto& e : estimators) {
+        e.BulkAdd(data_points);
+    }
+}
+
+}  // namespace duckdb

--- a/src/quantilelite.cpp
+++ b/src/quantilelite.cpp
@@ -1,0 +1,16 @@
+#include "quantilelite.hpp"
+
+#include <algorithm>
+
+namespace duckdb {
+
+float QuantileLite::Quantile(float q) {
+    if (samples.empty()) {
+        return 0.0;
+    }
+    const size_t k = static_cast<size_t>(q * (samples.size() - 1));
+    std::nth_element(samples.begin(), samples.begin() + k, samples.end());
+    return samples[k];
+}
+
+}  // namespace duckdb

--- a/unit/test_quantile_estimator.cpp
+++ b/unit/test_quantile_estimator.cpp
@@ -25,39 +25,39 @@ vector<int> GetRandomNumbers(int max_val) {
 } // namespace
 
 TEST_CASE("Small scale quantile test", "[quantile test]") {
-    constexpr size_t NUM_VALUE = 50;
-    constexpr double MAX_TOLERABLE_DIFF = 1.0;
+	constexpr size_t NUM_VALUE = 50;
+	constexpr double MAX_TOLERABLE_DIFF = 1.0;
 
-    QuantileEstimator qe;
-    const auto values = GetRandomNumbers(NUM_VALUE);
-    for (int cur_val : values) {
-        qe.Add(cur_val);
-    }
+	QuantileEstimator qe;
+	const auto values = GetRandomNumbers(NUM_VALUE);
+	for (int cur_val : values) {
+		qe.Add(cur_val);
+	}
 
-    const double p50 = qe.p50();
-    REQUIRE(p50 >= 25.5 - MAX_TOLERABLE_DIFF);
-    REQUIRE(p50 <= 25.5 + MAX_TOLERABLE_DIFF);
+	const double p50 = qe.p50();
+	REQUIRE(p50 >= 25.5 - MAX_TOLERABLE_DIFF);
+	REQUIRE(p50 <= 25.5 + MAX_TOLERABLE_DIFF);
 
-    const double p75 = qe.p75();
-    REQUIRE(p75 >= 37.5 - MAX_TOLERABLE_DIFF);
-    REQUIRE(p75 <= 37.5 + MAX_TOLERABLE_DIFF);
+	const double p75 = qe.p75();
+	REQUIRE(p75 >= 37.5 - MAX_TOLERABLE_DIFF);
+	REQUIRE(p75 <= 37.5 + MAX_TOLERABLE_DIFF);
 
-    const double p90 = qe.p90();
-    REQUIRE(p90 >= 45.0 - MAX_TOLERABLE_DIFF);
-    REQUIRE(p90 <= 45.0 + MAX_TOLERABLE_DIFF);
+	const double p90 = qe.p90();
+	REQUIRE(p90 >= 45.0 - MAX_TOLERABLE_DIFF);
+	REQUIRE(p90 <= 45.0 + MAX_TOLERABLE_DIFF);
 
-    const double p95 = qe.p95();
-    REQUIRE(p95 >= 47.5 - MAX_TOLERABLE_DIFF);
-    REQUIRE(p95 <= 47.5 + MAX_TOLERABLE_DIFF);
+	const double p95 = qe.p95();
+	REQUIRE(p95 >= 47.5 - MAX_TOLERABLE_DIFF);
+	REQUIRE(p95 <= 47.5 + MAX_TOLERABLE_DIFF);
 
-    const double p99 = qe.p99();
-    REQUIRE(p99 >= 49.5 - MAX_TOLERABLE_DIFF);
-    REQUIRE(p99 <= 49.5 + MAX_TOLERABLE_DIFF);
+	const double p99 = qe.p99();
+	REQUIRE(p99 >= 49.5 - MAX_TOLERABLE_DIFF);
+	REQUIRE(p99 <= 49.5 + MAX_TOLERABLE_DIFF);
 }
 
 TEST_CASE("Large scale quantile test", "[quantile test]") {
 	constexpr double MAX_TOLERABLE_DIFF = 10;
-    constexpr size_t NUM_VALUE = 1000;
+	constexpr size_t NUM_VALUE = 1000;
 
 	QuantileEstimator qe;
 	const auto values = GetRandomNumbers(NUM_VALUE);

--- a/unit/test_quantile_estimator.cpp
+++ b/unit/test_quantile_estimator.cpp
@@ -10,25 +10,57 @@
 using namespace duckdb; // NOLINT
 
 namespace {
-vector<int> GetRandomNumbers() {
-	constexpr size_t NUM_VALUE = 1000;
-	vector<int> v;
-	v.reserve(NUM_VALUE);
-	for (int i = 1; i <= NUM_VALUE; ++i) {
-		v.push_back(i);
+// Generate random numbers from [1, max_val].
+vector<int> GetRandomNumbers(int max_val) {
+	vector<int> numbers;
+	numbers.reserve(max_val);
+	for (int val = 1; val <= max_val; ++val) {
+		numbers.push_back(val);
 	}
 	std::random_device rd;
 	std::mt19937 g(rd());
-	std::shuffle(v.begin(), v.end(), g);
-	return v;
+	std::shuffle(numbers.begin(), numbers.end(), g);
+	return numbers;
 }
 } // namespace
 
-TEST_CASE("Quantile test", "[quantile test]") {
+TEST_CASE("Small scale quantile test", "[quantile test]") {
+    constexpr size_t NUM_VALUE = 50;
+    constexpr double MAX_TOLERABLE_DIFF = 1.0;
+
+    QuantileEstimator qe;
+    const auto values = GetRandomNumbers(NUM_VALUE);
+    for (int cur_val : values) {
+        qe.Add(cur_val);
+    }
+
+    const double p50 = qe.p50();
+    REQUIRE(p50 >= 25.5 - MAX_TOLERABLE_DIFF);
+    REQUIRE(p50 <= 25.5 + MAX_TOLERABLE_DIFF);
+
+    const double p75 = qe.p75();
+    REQUIRE(p75 >= 37.5 - MAX_TOLERABLE_DIFF);
+    REQUIRE(p75 <= 37.5 + MAX_TOLERABLE_DIFF);
+
+    const double p90 = qe.p90();
+    REQUIRE(p90 >= 45.0 - MAX_TOLERABLE_DIFF);
+    REQUIRE(p90 <= 45.0 + MAX_TOLERABLE_DIFF);
+
+    const double p95 = qe.p95();
+    REQUIRE(p95 >= 47.5 - MAX_TOLERABLE_DIFF);
+    REQUIRE(p95 <= 47.5 + MAX_TOLERABLE_DIFF);
+
+    const double p99 = qe.p99();
+    REQUIRE(p99 >= 49.5 - MAX_TOLERABLE_DIFF);
+    REQUIRE(p99 <= 49.5 + MAX_TOLERABLE_DIFF);
+}
+
+TEST_CASE("Large scale quantile test", "[quantile test]") {
 	constexpr double MAX_TOLERABLE_DIFF = 10;
+    constexpr size_t NUM_VALUE = 1000;
 
 	QuantileEstimator qe;
-	const auto values = GetRandomNumbers();
+	const auto values = GetRandomNumbers(NUM_VALUE);
 	for (int cur_val : values) {
 		qe.Add(cur_val);
 	}


### PR DESCRIPTION
Followup for https://github.com/dentiny/duckdb-filesystem-observability/pull/17, which uses P2 algorithm to calculate quantile value and is known to be imprecise when dataset scale small.

Considering people don't expect inaccurate value when dataset small, I store raw data in-memory and cap the upper-bound at 4 bytes (float) * 512 = 2KiB per quantile calculator.