### PR TITLE
Integrate quantile into output string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(EXTENSION_SOURCES
     src/metrics_collector.cpp
     src/observefs_extension.cpp
     src/observability_filesystem.cpp
-    src/operation_latency_histogram.cpp
+    src/operation_latency_collector.cpp
     src/quantile.cpp
     src/quantilelite.cpp
     src/quantile_estimator.cpp

--- a/src/histogram.cpp
+++ b/src/histogram.cpp
@@ -60,32 +60,6 @@ double Histogram::mean() const {
 	return sum_ / total_counts_;
 }
 
-double Histogram::Quantile(double q) const {
-	D_ASSERT(q >= 0.0 && q <= 1.0);
-	if (total_counts_ == 0) {
-		return 0.0;
-	}
-
-	size_t target_rank = static_cast<size_t>(std::ceil(q * total_counts_));
-	size_t cumulative = 0;
-	const double interval = (max_val_ - min_val_) / num_bkt_;
-
-	for (size_t idx = 0; idx < hist_.size(); ++idx) {
-		size_t bucket_count = hist_[idx];
-		if (bucket_count == 0) {
-			continue;
-		}
-		if (cumulative + bucket_count >= target_rank) {
-			const double cur_min_val = min_val_ + interval * idx;
-			const double fraction_in_bucket = (target_rank - cumulative) * 1.0 / bucket_count;
-			return cur_min_val + fraction_in_bucket * interval;
-		}
-		cumulative += bucket_count;
-	}
-
-	return max_encountered_;
-}
-
 std::string Histogram::FormatString() const {
 	std::string res;
 
@@ -102,14 +76,6 @@ std::string Histogram::FormatString() const {
 	res += StringUtil::Format("Max %s = %lf %s\n", distribution_name_, max(), distribution_unit_);
 	res += StringUtil::Format("Min %s = %lf %s\n", distribution_name_, min(), distribution_unit_);
 	res += StringUtil::Format("Mean %s = %lf %s\n", distribution_name_, mean(), distribution_unit_);
-
-	// Format quantiles.
-	res += "Rough estimation for quantiles:\n";
-	res += StringUtil::Format("p50 = %lf %s\n", p50(), distribution_unit_);
-	res += StringUtil::Format("p75 = %lf %s\n", p75(), distribution_unit_);
-	res += StringUtil::Format("p90 = %lf %s\n", p90(), distribution_unit_);
-	res += StringUtil::Format("p95 = %lf %s\n", p95(), distribution_unit_);
-	res += StringUtil::Format("p99 = %lf %s\n", p99(), distribution_unit_);
 
 	// Format stats distribution.
 	const double interval = (max_val_ - min_val_) / num_bkt_;

--- a/src/include/histogram.hpp
+++ b/src/include/histogram.hpp
@@ -47,26 +47,6 @@ public:
 		return max_encountered_;
 	}
 
-	// Get rough estimation for quantile.
-	double p50() const {
-		return Quantile(0.50);
-	}
-	double p75() const {
-		return Quantile(0.75);
-	}
-	double p90() const {
-		return Quantile(0.90);
-	}
-	double p95() const {
-		return Quantile(0.95);
-	}
-	double p99() const {
-		return Quantile(0.99);
-	}
-	double p100() const {
-		return max_encountered_;
-	}
-
 	// Get outliers for stat records.
 	const std::vector<double> outliers() const {
 		return outliers_;
@@ -79,9 +59,6 @@ public:
 	void Reset();
 
 private:
-	// Notice it't not accurate based on bucketization.
-	double Quantile(double q) const;
-
 	const double min_val_;
 	const double max_val_;
 	const int num_bkt_;

--- a/src/include/metrics_collector.hpp
+++ b/src/include/metrics_collector.hpp
@@ -6,7 +6,7 @@
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
 #include "histogram.hpp"
-#include "operation_latency_histogram.hpp"
+#include "operation_latency_collector.hpp"
 
 namespace duckdb {
 
@@ -45,9 +45,9 @@ public:
 private:
 	// Overall latency histogram.
 	std::mutex latency_histogram_mu;
-	unique_ptr<OperationLatencyHistogram> overall_latency_histogram_;
+	unique_ptr<OperationLatencyCollector> overall_latency_histogram_;
 	// Bucket-wise latency histogram.
-	unordered_map<string, unique_ptr<OperationLatencyHistogram>> bucket_latency_histogram_;
+	unordered_map<string, unique_ptr<OperationLatencyCollector>> bucket_latency_histogram_;
 };
 
 } // namespace duckdb

--- a/src/include/operation_latency_collector.hpp
+++ b/src/include/operation_latency_collector.hpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 
 // Forward declaration.
-class OperationLatencyHistogram;
+class OperationLatencyCollector;
 
 // IO operation types.
 //
@@ -29,7 +29,7 @@ enum class IoOperation {
 // A RAII guard to measure latency for IO operations.
 class LatencyGuard {
 public:
-	LatencyGuard(OperationLatencyHistogram &latency_collector_p, IoOperation io_operation_p);
+	LatencyGuard(OperationLatencyCollector &latency_collector_p, IoOperation io_operation_p);
 	~LatencyGuard();
 
 	LatencyGuard(const LatencyGuard &) = delete;
@@ -38,15 +38,15 @@ public:
 	LatencyGuard &operator=(LatencyGuard &&) = default;
 
 private:
-	OperationLatencyHistogram &latency_collector;
+	OperationLatencyCollector &latency_collector;
 	IoOperation io_operation = IoOperation::kUnknown;
 	int64_t start_timestamp = 0;
 };
 
-class OperationLatencyHistogram {
+class OperationLatencyCollector {
 public:
-	OperationLatencyHistogram();
-	~OperationLatencyHistogram() = default;
+	OperationLatencyCollector();
+	~OperationLatencyCollector() = default;
 
 	LatencyGuard RecordOperationStart(IoOperation io_oper);
 

--- a/src/include/operation_latency_histogram.hpp
+++ b/src/include/operation_latency_histogram.hpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
 #include "histogram.hpp"
+#include "quantile_estimator.hpp"
 
 namespace duckdb {
 
@@ -55,6 +56,11 @@ public:
 private:
 	friend class LatencyGuard;
 
+	struct LatencyStatsCollector {
+		unique_ptr<Histogram> histogram;
+		unique_ptr<QuantileEstimator> quantile_estimator;
+	};
+
 	// Mark the end of the a completed IO operation, disregard it's successful or not.
 	void RecordOperationEnd(IoOperation io_oper, int64_t latency_millisec);
 
@@ -71,8 +77,8 @@ private:
 	}();
 
 	// Only records finished operations, which maps from io operation to histogram.
-	std::mutex histogram_mu;
-	std::array<unique_ptr<Histogram>, kIoOperationCount> histograms;
+	std::mutex latency_collector_mu;
+	std::array<LatencyStatsCollector, kIoOperationCount> latency_collector;
 };
 
 } // namespace duckdb

--- a/src/include/quantile_estimator.hpp
+++ b/src/include/quantile_estimator.hpp
@@ -2,7 +2,9 @@
 
 #include <array>
 #include <mutex>
+#include <utility>
 
+#include "duckdb/common/string.hpp"
 #include "duckdb/common/vector.hpp"
 #include "quantile.hpp"
 #include "quantilelite.hpp"
@@ -11,21 +13,30 @@ namespace duckdb {
 
 class QuantileEstimator {
 public:
-    QuantileEstimator() = default;
+    QuantileEstimator(string name_p, string unit_p)
+        : quantile_name(std::move(name_p)), 
+          quantile_unit(std::move(unit_p)) {}
     ~QuantileEstimator() = default;
 
     // Add the given value to quantile calculator.
     void Add(float x);
 
-    float p50();
-    float p75();
-    float p90();
-    float p95();
-    float p99();
+    float p50() const;
+    float p75() const;
+    float p90() const;
+    float p95() const;
+    float p99() const;
+
+    // Return human-readable string for quantile stats.
+    string FormatString() const;
 
 private:
     // Initialize P2 quantile.
     void InitializeP2QuantileWithLock();
+
+    // Metrics name and unit.
+    string quantile_name;
+    string quantile_unit;
 
     // Used to trigger large-scale data point ingestion.
     inline static constexpr size_t LARGE_SCALE_DATA_POINT_THRESHOLD = 512;

--- a/src/include/quantilelite.hpp
+++ b/src/include/quantilelite.hpp
@@ -29,26 +29,26 @@ public:
         return samples.size();
     }
 
-    float p50() {
+    float p50() const {
         return Quantile(0.50); 
     }
-    float p75() {
+    float p75() const {
         return Quantile(0.75); 
     }
-    float p90() {
+    float p90() const {
         return Quantile(0.90); 
     }
-    float p95() {
+    float p95() const {
         return Quantile(0.95); 
     }
-    float p99() {
+    float p99() const {
         return Quantile(0.99); 
     }
 
 private:
-    float Quantile(float q);
+    float Quantile(float q) const;
 
-    vector<float> samples;
+    mutable vector<float> samples;
 };
 
 }  // namespace duckdb

--- a/src/metrics_collector.cpp
+++ b/src/metrics_collector.cpp
@@ -11,7 +11,7 @@ void LatencyGuardWrapper::TakeGuard(LatencyGuard latency_guard) {
 	latency_guards.emplace_back(std::move(latency_guard));
 }
 
-MetricsCollector::MetricsCollector() : overall_latency_histogram_(make_uniq<OperationLatencyHistogram>()) {
+MetricsCollector::MetricsCollector() : overall_latency_histogram_(make_uniq<OperationLatencyCollector>()) {
 }
 
 LatencyGuardWrapper MetricsCollector::RecordOperationStart(IoOperation io_oper, const string &filepath) {
@@ -25,7 +25,7 @@ LatencyGuardWrapper MetricsCollector::RecordOperationStart(IoOperation io_oper, 
 	if (!bucket.empty()) {
         auto& cur_bucket_hist = bucket_latency_histogram_[bucket];
         if (cur_bucket_hist == nullptr) {
-            cur_bucket_hist = make_uniq<OperationLatencyHistogram>();
+            cur_bucket_hist = make_uniq<OperationLatencyCollector>();
         }
 		auto bucket_latency_guard = cur_bucket_hist->RecordOperationStart(io_oper);
 		guard_wrapper.TakeGuard(std::move(bucket_latency_guard));
@@ -48,7 +48,7 @@ std::string MetricsCollector::GetHumanReadableStats() {
 
 void MetricsCollector::Reset() {
 	std::lock_guard<std::mutex> lck(latency_histogram_mu);
-	overall_latency_histogram_ = make_uniq<OperationLatencyHistogram>();
+	overall_latency_histogram_ = make_uniq<OperationLatencyCollector>();
     bucket_latency_histogram_.clear();
 }
 

--- a/src/quantile_estimator.cpp
+++ b/src/quantile_estimator.cpp
@@ -1,5 +1,7 @@
 #include "quantile_estimator.hpp"
 
+#include "duckdb/common/string_util.hpp"
+
 namespace duckdb {
 
 void QuantileEstimator::Add(float x) {
@@ -24,35 +26,35 @@ void QuantileEstimator::Add(float x) {
     quantile_lite.Add(x);
 }
 
-float QuantileEstimator::p50() {
+float QuantileEstimator::p50() const {
     std::lock_guard<std::mutex> lck(mu);
     if (estimators.empty()) {
         return quantile_lite.p50();
     }
     return estimators[0].Get(); 
 }
-float QuantileEstimator::p75() {
+float QuantileEstimator::p75() const {
     std::lock_guard<std::mutex> lck(mu);
     if (estimators.empty()) {
         return quantile_lite.p75();
     }
     return estimators[1].Get(); 
 }
-float QuantileEstimator::p90() {
+float QuantileEstimator::p90() const {
     std::lock_guard<std::mutex> lck(mu);
     if (estimators.empty()) {
         return quantile_lite.p90();
     }
     return estimators[2].Get(); 
 }
-float QuantileEstimator::p95() {
+float QuantileEstimator::p95() const {
     std::lock_guard<std::mutex> lck(mu);
     if (estimators.empty()) {
         return quantile_lite.p95();
     }
     return estimators[3].Get(); 
 }
-float QuantileEstimator::p99() {
+float QuantileEstimator::p99() const {
     std::lock_guard<std::mutex> lck(mu);
     if (estimators.empty()) {
         return quantile_lite.p99();
@@ -72,6 +74,16 @@ void QuantileEstimator::InitializeP2QuantileWithLock() {
     for (auto& e : estimators) {
         e.BulkAdd(data_points);
     }
+}
+
+string QuantileEstimator::FormatString() const {
+    string stats;
+    stats += StringUtil::Format("\nP50 %s %f %s", quantile_name, p50(), quantile_unit);
+    stats += StringUtil::Format("\nP75 %s %f %s", quantile_name, p75(), quantile_unit);
+    stats += StringUtil::Format("\nP90 %s %f %s", quantile_name, p90(), quantile_unit);
+    stats += StringUtil::Format("\nP95 %s %f %s", quantile_name, p95(), quantile_unit);
+    stats += StringUtil::Format("\nP99 %s %f %s", quantile_name, p99(), quantile_unit);
+    return stats;
 }
 
 }  // namespace duckdb

--- a/src/quantilelite.cpp
+++ b/src/quantilelite.cpp
@@ -4,7 +4,7 @@
 
 namespace duckdb {
 
-float QuantileLite::Quantile(float q) {
+float QuantileLite::Quantile(float q) const {
     if (samples.empty()) {
         return 0.0;
     }

--- a/unit/test_quantile_estimator.cpp
+++ b/unit/test_quantile_estimator.cpp
@@ -31,7 +31,7 @@ TEST_CASE("Small scale quantile test", "[quantile test]") {
 	constexpr size_t NUM_VALUE = 50;
 	constexpr double MAX_TOLERABLE_DIFF = 1.0;
 
-	QuantileEstimator qe{METRICS_NAME, METRICS_UNIT};
+	QuantileEstimator qe {METRICS_NAME, METRICS_UNIT};
 	const auto values = GetRandomNumbers(NUM_VALUE);
 	for (int cur_val : values) {
 		qe.Add(cur_val);
@@ -62,7 +62,7 @@ TEST_CASE("Large scale quantile test", "[quantile test]") {
 	constexpr double MAX_TOLERABLE_DIFF = 10;
 	constexpr size_t NUM_VALUE = 1000;
 
-	QuantileEstimator qe{METRICS_NAME, METRICS_UNIT};
+	QuantileEstimator qe {METRICS_NAME, METRICS_UNIT};
 	const auto values = GetRandomNumbers(NUM_VALUE);
 	for (int cur_val : values) {
 		qe.Add(cur_val);

--- a/unit/test_quantile_estimator.cpp
+++ b/unit/test_quantile_estimator.cpp
@@ -10,6 +10,9 @@
 using namespace duckdb; // NOLINT
 
 namespace {
+const std::string METRICS_NAME = "metrics_name";
+const std::string METRICS_UNIT = "metrics_unit";
+
 // Generate random numbers from [1, max_val].
 vector<int> GetRandomNumbers(int max_val) {
 	vector<int> numbers;
@@ -28,7 +31,7 @@ TEST_CASE("Small scale quantile test", "[quantile test]") {
 	constexpr size_t NUM_VALUE = 50;
 	constexpr double MAX_TOLERABLE_DIFF = 1.0;
 
-	QuantileEstimator qe;
+	QuantileEstimator qe{METRICS_NAME, METRICS_UNIT};
 	const auto values = GetRandomNumbers(NUM_VALUE);
 	for (int cur_val : values) {
 		qe.Add(cur_val);
@@ -59,7 +62,7 @@ TEST_CASE("Large scale quantile test", "[quantile test]") {
 	constexpr double MAX_TOLERABLE_DIFF = 10;
 	constexpr size_t NUM_VALUE = 1000;
 
-	QuantileEstimator qe;
+	QuantileEstimator qe{METRICS_NAME, METRICS_UNIT};
 	const auto values = GetRandomNumbers(NUM_VALUE);
 	for (int cur_val : values) {
 		qe.Add(cur_val);


### PR DESCRIPTION
This PR integrates quantile collector into latency metrics collector, which replaces the inaccurate one from histogram.