### PR TITLE
Fix httpfs registration

### DIFF
--- a/src/fake_filesystem.cpp
+++ b/src/fake_filesystem.cpp
@@ -11,75 +11,75 @@ namespace {
 const NoDestructor<std::string> FAKE_FILESYSTEM_PREFIX {"/tmp/cache_httpfs_fake_filesystem"};
 } // namespace
 
-CacheHttpfsFakeFsHandle::CacheHttpfsFakeFsHandle(string path, unique_ptr<FileHandle> internal_file_handle_p,
-                                                 CacheHttpfsFakeFileSystem &fs)
+ObserveHttpfsFakeFsHandle::ObserveHttpfsFakeFsHandle(string path, unique_ptr<FileHandle> internal_file_handle_p,
+                                                     ObserveHttpfsFakeFileSystem &fs)
     : FileHandle(fs, std::move(path), internal_file_handle_p->GetFlags()),
       internal_file_handle(std::move(internal_file_handle_p)) {
 }
-CacheHttpfsFakeFileSystem::CacheHttpfsFakeFileSystem() : local_filesystem(LocalFileSystem::CreateLocal()) {
+ObserveHttpfsFakeFileSystem::ObserveHttpfsFakeFileSystem() : local_filesystem(LocalFileSystem::CreateLocal()) {
 	local_filesystem->CreateDirectory(*FAKE_FILESYSTEM_PREFIX);
 }
-bool CacheHttpfsFakeFileSystem::CanHandleFile(const string &path) {
+bool ObserveHttpfsFakeFileSystem::CanHandleFile(const string &path) {
 	return StringUtil::StartsWith(path, *FAKE_FILESYSTEM_PREFIX);
 }
 
-unique_ptr<FileHandle> CacheHttpfsFakeFileSystem::OpenFile(const string &path, FileOpenFlags flags,
-                                                           optional_ptr<FileOpener> opener) {
+unique_ptr<FileHandle> ObserveHttpfsFakeFileSystem::OpenFile(const string &path, FileOpenFlags flags,
+                                                             optional_ptr<FileOpener> opener) {
 	auto file_handle = local_filesystem->OpenFile(path, flags, opener);
-	return make_uniq<CacheHttpfsFakeFsHandle>(path, std::move(file_handle), *this);
+	return make_uniq<ObserveHttpfsFakeFsHandle>(path, std::move(file_handle), *this);
 }
-void CacheHttpfsFakeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+void ObserveHttpfsFakeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	local_filesystem->Read(*local_filesystem_handle, buffer, nr_bytes, location);
 }
-int64_t CacheHttpfsFakeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+int64_t ObserveHttpfsFakeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	return local_filesystem->Read(*local_filesystem_handle, buffer, nr_bytes);
 }
 
-void CacheHttpfsFakeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+void ObserveHttpfsFakeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	local_filesystem->Write(*local_filesystem_handle, buffer, nr_bytes, location);
 }
-int64_t CacheHttpfsFakeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+int64_t ObserveHttpfsFakeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	return local_filesystem->Write(*local_filesystem_handle, buffer, nr_bytes);
 }
-int64_t CacheHttpfsFakeFileSystem::GetFileSize(FileHandle &handle) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+int64_t ObserveHttpfsFakeFileSystem::GetFileSize(FileHandle &handle) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	return local_filesystem->GetFileSize(*local_filesystem_handle);
 }
-void CacheHttpfsFakeFileSystem::FileSync(FileHandle &handle) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+void ObserveHttpfsFakeFileSystem::FileSync(FileHandle &handle) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	local_filesystem->FileSync(*local_filesystem_handle);
 }
 
-void CacheHttpfsFakeFileSystem::Seek(FileHandle &handle, idx_t location) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+void ObserveHttpfsFakeFileSystem::Seek(FileHandle &handle, idx_t location) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	local_filesystem->Seek(*local_filesystem_handle, location);
 }
-idx_t CacheHttpfsFakeFileSystem::SeekPosition(FileHandle &handle) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+idx_t ObserveHttpfsFakeFileSystem::SeekPosition(FileHandle &handle) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	return local_filesystem->SeekPosition(*local_filesystem_handle);
 }
-bool CacheHttpfsFakeFileSystem::Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+bool ObserveHttpfsFakeFileSystem::Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	return local_filesystem->Trim(*local_filesystem_handle, offset_bytes, length_bytes);
 }
-timestamp_t CacheHttpfsFakeFileSystem::GetLastModifiedTime(FileHandle &handle) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+timestamp_t ObserveHttpfsFakeFileSystem::GetLastModifiedTime(FileHandle &handle) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	return local_filesystem->GetLastModifiedTime(*local_filesystem_handle);
 }
-FileType CacheHttpfsFakeFileSystem::GetFileType(FileHandle &handle) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+FileType ObserveHttpfsFakeFileSystem::GetFileType(FileHandle &handle) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	return local_filesystem->GetFileType(*local_filesystem_handle);
 }
-void CacheHttpfsFakeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+void ObserveHttpfsFakeFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	local_filesystem->Truncate(*local_filesystem_handle, new_size);
 }
-bool CacheHttpfsFakeFileSystem::OnDiskFile(FileHandle &handle) {
-	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+bool ObserveHttpfsFakeFileSystem::OnDiskFile(FileHandle &handle) {
+	auto &local_filesystem_handle = handle.Cast<ObserveHttpfsFakeFsHandle>().internal_file_handle;
 	return local_filesystem->OnDiskFile(*local_filesystem_handle);
 }
 

--- a/src/include/fake_filesystem.hpp
+++ b/src/include/fake_filesystem.hpp
@@ -8,12 +8,13 @@
 namespace duckdb {
 
 // Forward declaration.
-class CacheHttpfsFakeFileSystem;
+class ObserveHttpfsFakeFileSystem;
 
-class CacheHttpfsFakeFsHandle : public FileHandle {
+class ObserveHttpfsFakeFsHandle : public FileHandle {
 public:
-	CacheHttpfsFakeFsHandle(string path, unique_ptr<FileHandle> internal_file_handle_p, CacheHttpfsFakeFileSystem &fs);
-	~CacheHttpfsFakeFsHandle() override = default;
+	ObserveHttpfsFakeFsHandle(string path, unique_ptr<FileHandle> internal_file_handle_p,
+	                          ObserveHttpfsFakeFileSystem &fs);
+	~ObserveHttpfsFakeFsHandle() override = default;
 	void Close() override {
 		internal_file_handle->Close();
 	}
@@ -22,9 +23,9 @@ public:
 };
 
 // WARNING: fake filesystem is used for testing purpose and shouldn't be used in production.
-class CacheHttpfsFakeFileSystem : public LocalFileSystem {
+class ObserveHttpfsFakeFileSystem : public LocalFileSystem {
 public:
-	CacheHttpfsFakeFileSystem();
+	ObserveHttpfsFakeFileSystem();
 	bool CanHandleFile(const string &path) override;
 	std::string GetName() const override {
 		return "observefs_fake_filesystem";

--- a/test/sql/extension.test
+++ b/test/sql/extension.test
@@ -8,3 +8,11 @@ query I
 SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name = 'observefs';
 ----
 1
+
+query I
+SELECT unnest(observefs_list_registered_filesystems());
+----
+observability-HTTPFileSystem
+observability-HuggingFaceFileSystem
+observability-S3FileSystem
+observefs_fake_filesystem


### PR DESCRIPTION
This PR does two things:
- Fix a bug that all httpfs filesystems are registered twice! One as raw filesystem, one wrapped in observefs
- Add a list filesystem function, so users could know what's available filesystem before they wrap