### PR TITLE
Refine list filesystem query function to table function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ include_directories(duckdb/third_party/httplib)
 set(EXTENSION_SOURCES
     src/fake_filesystem.cpp
     src/filesystem_ref_registry.cpp
+    src/filesystem_status_query_function.cpp
     src/histogram.cpp
     src/metrics_collector.cpp
     src/numeric_utils.cpp

--- a/src/filesystem_status_query_function.cpp
+++ b/src/filesystem_status_query_function.cpp
@@ -1,0 +1,93 @@
+#include "filesystem_status_query_function.hpp"
+
+#include <algorithm>
+
+#include "duckdb/common/opener_file_system.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/function/function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
+
+namespace duckdb {
+
+namespace {
+
+//===--------------------------------------------------------------------===//
+// List registered filesystems query function
+//===--------------------------------------------------------------------===//
+
+struct ListFileSystemData : public GlobalTableFunctionState {
+	vector<string> registered_filesystems;
+
+	// Used to record the progress of emission.
+	uint64_t offset = 0;
+};
+
+unique_ptr<FunctionData> ListFileSystemQueryFuncBind(ClientContext &context, TableFunctionBindInput &input,
+                                                     vector<LogicalType> &return_types, vector<string> &names) {
+	D_ASSERT(return_types.empty());
+	D_ASSERT(names.empty());
+
+	return_types.reserve(1);
+	names.reserve(1);
+
+	// Registered filesystems.
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("registered_filesystems");
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> ListFileSystemQueryFuncInit(ClientContext &context,
+                                                                 TableFunctionInitInput &input) {
+	auto result = make_uniq<ListFileSystemData>();
+	auto &entries_info = result->registered_filesystems;
+
+	auto &duckdb_instance = context.db;
+	auto &opener_filesystem = duckdb_instance->GetFileSystem().Cast<OpenerFileSystem>();
+	auto &vfs = opener_filesystem.GetFileSystem();
+	auto filesystems = vfs.ListSubSystems();
+
+	// Sort the results to ensure determinististism and testibility.
+	std::sort(filesystems.begin(), filesystems.end());
+	entries_info = std::move(filesystems);
+
+	return std::move(result);
+}
+
+void ListFileSystemQueryTableFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<ListFileSystemData>();
+
+	// All entries have been emitted.
+	if (data.offset >= data.registered_filesystems.size()) {
+		return;
+	}
+
+	// Start filling in the result buffer.
+	idx_t count = 0;
+	while (data.offset < data.registered_filesystems.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.registered_filesystems[data.offset++];
+		idx_t col = 0;
+
+		// Registerd filesystem.
+		output.SetValue(col++, count, entry);
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+} // namespace
+
+TableFunction ListRegisteredFileSystemsQueryFunc() {
+	TableFunction list_filesystems_query_func {/*name=*/"observefs_list_registered_filesystems",
+	                                           /*arguments=*/ {},
+	                                           /*function=*/ListFileSystemQueryTableFunc,
+	                                           /*bind=*/ListFileSystemQueryFuncBind,
+	                                           /*init_global=*/ListFileSystemQueryFuncInit};
+	return list_filesystems_query_func;
+}
+
+} // namespace duckdb

--- a/src/include/filesystem_status_query_function.hpp
+++ b/src/include/filesystem_status_query_function.hpp
@@ -1,0 +1,12 @@
+// Functions which query duckdb filesystem status.
+
+#pragma once
+
+#include "duckdb/function/table_function.hpp"
+
+namespace duckdb {
+
+// List the registered filesystem instances.
+TableFunction ListRegisteredFileSystemsQueryFunc();
+
+} // namespace duckdb

--- a/src/observefs_extension.cpp
+++ b/src/observefs_extension.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/unique_ptr.hpp"
 #include "fake_filesystem.hpp"
 #include "filesystem_ref_registry.hpp"
+#include "filesystem_status_query_function.hpp"
 #include "hffs.hpp"
 #include "httpfs_extension.hpp"
 #include "observefs_extension.hpp"
@@ -192,11 +193,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(get_profile_stats_function);
 
 	// Register a function to list all existing filesystem instances, which is useful for wrapping.
-	ScalarFunction list_registered_filesystem_function("observefs_list_registered_filesystems",
-	                                                   /*arguments=*/ {},
-	                                                   /*return_type=*/LogicalType::LIST(LogicalType::VARCHAR),
-	                                                   ListRegisteredFileSystems);
-	loader.RegisterFunction(list_registered_filesystem_function);
+	loader.RegisterFunction(ListRegisteredFileSystemsQueryFunc());
 
 	// Register a function to wrap all duckdb-vfs-compatible filesystems. By default only httpfs filesystem instances
 	// are wrapped. Usage for the target filesystem can be used as normal.

--- a/test/sql/extension.test
+++ b/test/sql/extension.test
@@ -10,7 +10,7 @@ SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name = 'observefs';
 1
 
 query I
-SELECT unnest(observefs_list_registered_filesystems());
+SELECT * FROM observefs_list_registered_filesystems();
 ----
 observability-HTTPFileSystem
 observability-HuggingFaceFileSystem


### PR DESCRIPTION
Current implementation emits a list of filesystem names in a `LIST` type, which is functionally correct but miss a few if your screen is not large enough.
For example,
```sql
D SELECT observefs_list_registered_filesystems();
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                      observefs_list_registered_filesystems()                                      │
│                                                      varchar[]                                                       │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ [AzureBlobStorageFileSystem, AzureDfsStorageFileSystem, cache_httpfs_HTTPFileSystem, cache_httpfs_HuggingFaceFileS…  │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```
We could workaround by using `unnest`: `SELECT unnest(observefs_list_registered_filesystems());`

This PR changes the scalar function into table function, so it print out all filesystems in a nicer way.
```sql
D LOAD azure;
D SELECT * FROM observefs_list_registered_filesystems();
┌─────────────────────────────────────┐
│       registered_filesystems        │
│               varchar               │
├─────────────────────────────────────┤
│ AzureBlobStorageFileSystem          │
│ AzureDfsStorageFileSystem           │
│ observability-HTTPFileSystem        │
│ observability-HuggingFaceFileSystem │
│ observability-S3FileSystem          │
│ observefs_fake_filesystem           │
└─────────────────────────────────────┘
```