### PR TITLE
Add stats for glob and get file size

### DIFF
--- a/src/include/io_operation.hpp
+++ b/src/include/io_operation.hpp
@@ -1,3 +1,7 @@
+// Necessary changes to add a new IO operation:
+// 1. Add new IO operations to [`IoOperation`] enum class
+// 2. Add estimated latency to [`kLatencyHeuristics`]
+
 #pragma once
 
 #include <array>

--- a/src/include/operation_latency_collector.hpp
+++ b/src/include/operation_latency_collector.hpp
@@ -31,6 +31,10 @@ inline constexpr std::array<LatencyHeuristic, static_cast<size_t>(IoOperation::k
     {0, 1000, 100},
     // kList
     {0, 3000, 100},
+    // kGlob
+    {0, 3000, 100},
+    // kGetFileSize,
+    {0, 1000, 100},
 }};
 
 // A RAII guard to measure latency for IO operations.

--- a/src/observability_filesystem.cpp
+++ b/src/observability_filesystem.cpp
@@ -43,7 +43,7 @@ unique_ptr<FileHandle> ObservabilityFileSystem::OpenFile(const string &path, Fil
 	return make_uniq<ObservabilityFileSystemHandle>(std::move(file_handle), *this);
 }
 int64_t ObservabilityFileSystem::GetFileSize(FileHandle &handle) {
-	const auto latency_guard = metrics_collector.RecordOperationStart(IoOperation::kOpen, handle.GetPath());
+	const auto latency_guard = metrics_collector.RecordOperationStart(IoOperation::kGetFileSize, handle.GetPath());
 	auto &observability_file_handle = handle.Cast<ObservabilityFileSystemHandle>();
 	return internal_filesystem->GetFileSize(*observability_file_handle.internal_file_handle);
 }


### PR DESCRIPTION
This PR adds stats for two more read operations: glob and getting file size; 
so as of now, all read operations should be covered by observefs.