### PR TITLE
[minor] Update stats output format

### DIFF
--- a/src/metrics_collector.cpp
+++ b/src/metrics_collector.cpp
@@ -66,7 +66,7 @@ std::string MetricsCollector::GetHumanReadableStats() {
 	// Collect request size stats.
 	const auto size_stats = operation_size_collector_->GetHumanReadableStats();
 	if (!size_stats.empty()) {
-		human_readable_stats += StringUtil::Format("Request size: \n%s\n", size_stats);
+		human_readable_stats += StringUtil::Format("\nRequest size: %s\n", size_stats);
 	}
 
 	return human_readable_stats;

--- a/src/operation_latency_collector.cpp
+++ b/src/operation_latency_collector.cpp
@@ -56,7 +56,7 @@ std::string OperationLatencyCollector::GetHumanReadableStats() {
 		if (cur_histogram->counts() == 0) {
 			continue;
 		}
-		stats += StringUtil::Format("\n%s operation histogram is %s", OPER_NAMES[cur_oper_idx],
+		stats += StringUtil::Format("\n\n%s operation histogram is %s", OPER_NAMES[cur_oper_idx],
 		                            cur_histogram->FormatString());
 
 		// Check important quantiles.


### PR DESCRIPTION
This PR patch minor updates to the output format. Example query and output:
```sql
D SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│     251      │
└──────────────┘
D COPY (SELECT observefs_get_profile()) TO '/tmp/output.txt';
```
Output result:
```sh
observefs_get_profile()
"Current filesystem: observability-HTTPFileSystem
Overall latency: 


open operation histogram is Max latency = 85.000000 millisec
Min latency = 0.000000 millisec
Mean latency = 28.333333 millisec
Count = 3
Distribution latency [0.000000, 10.000000) millisec: 66.666667 %
Distribution latency [80.000000, 90.000000) millisec: 33.333333 %

open operation quantile is 
P50 latency 0.000000 millisec
P75 latency 42.500000 millisec
P90 latency 67.999992 millisec
P95 latency 76.500000 millisec
P99 latency 83.300003 millisec

read operation histogram is Max latency = 22.000000 millisec
Min latency = 0.000000 millisec
Mean latency = 3.666667 millisec
Count = 6
Distribution latency [0.000000, 10.000000) millisec: 83.333333 %
Distribution latency [20.000000, 30.000000) millisec: 16.666667 %

read operation quantile is 
P50 latency 0.000000 millisec
P75 latency 0.000000 millisec
P90 latency 11.000000 millisec
P95 latency 16.500000 millisec
P99 latency 20.899996 millisec

glob operation histogram is Max latency = 0.000000 millisec
Min latency = 0.000000 millisec
Mean latency = 0.000000 millisec
Count = 3
Distribution latency [0.000000, 30.000000) millisec: 100.000000 %

glob operation quantile is 
P50 latency 0.000000 millisec
P75 latency 0.000000 millisec
P90 latency 0.000000 millisec
P95 latency 0.000000 millisec
P99 latency 0.000000 millisec

get_file_size operation histogram is Max latency = 0.000000 millisec
Min latency = 0.000000 millisec
Mean latency = 0.000000 millisec
Count = 3
Distribution latency [0.000000, 10.000000) millisec: 100.000000 %

get_file_size operation quantile is 
P50 latency 0.000000 millisec
P75 latency 0.000000 millisec
P90 latency 0.000000 millisec
P95 latency 0.000000 millisec
P99 latency 0.000000 millisec

Request size: 
read operation histogram is Max  = 16222.000000 
Min  = 0.000000 
Mean  = 8111.000000 
Count = 2
Distribution  [0.000000, 49152.000000) : 100.000000 %


Current filesystem: observability-HuggingFaceFileSystem
No interested IO operations issued.
Current filesystem: observability-S3FileSystem
No interested IO operations issued.
"
```