### PR TITLE
Make filesystem registry per-instance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,9 @@ set(EXTENSION_SOURCES
     src/histogram.cpp
     src/metrics_collector.cpp
     src/numeric_utils.cpp
-    src/observefs_extension.cpp
     src/observability_filesystem.cpp
+    src/observefs_extension.cpp
+    src/observefs_instance_state.cpp
     src/operation_latency_collector.cpp
     src/operation_size_collector.cpp
     src/quantile.cpp

--- a/src/include/filesystem_ref_registry.hpp
+++ b/src/include/filesystem_ref_registry.hpp
@@ -1,7 +1,9 @@
-// CacheFsRefRegistry is a singleton registry which stores references for all cache filesystems.
-// The class is not thread-safe.
+// CacheFsRefRegistry is a registry which stores references for all cache filesystems.
+// The class is thread-safe.
 
 #pragma once
+
+#include <mutex>
 
 #include "duckdb/common/vector.hpp"
 
@@ -12,9 +14,6 @@ class ObservabilityFileSystem;
 
 class ObservabilityFsRefRegistry {
 public:
-	// Get the singleton instance for the registry.
-	static ObservabilityFsRefRegistry &Get();
-
 	// Register the cache filesystem to the registry.
 	void Register(ObservabilityFileSystem *fs);
 
@@ -22,11 +21,10 @@ public:
 	void Reset();
 
 	// Get all cache filesystems.
-	const vector<ObservabilityFileSystem *> &GetAllObservabilityFs() const;
+	vector<ObservabilityFileSystem *> GetAllObservabilityFs() const;
 
 private:
-	ObservabilityFsRefRegistry() = default;
-
+	mutable std::mutex mu;
 	// The ownership lies in db instance.
 	vector<ObservabilityFileSystem *> observability_filesystems;
 };

--- a/src/include/observability_filesystem.hpp
+++ b/src/include/observability_filesystem.hpp
@@ -51,7 +51,8 @@ public:
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	// Does update file offset (which acts as `Read` semantics).
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
-	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener = nullptr) override;
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+	                                optional_ptr<FileOpener> opener = nullptr) override;
 	std::string GetName() const override;
 	// Get file size.
 	int64_t GetFileSize(FileHandle &handle) override;

--- a/src/include/observefs_instance_state.hpp
+++ b/src/include/observefs_instance_state.hpp
@@ -1,0 +1,50 @@
+// Per-instance state for observefs extension.
+// State is stored in DuckDB's ObjectCache for automatic cleanup when DatabaseInstance is destroyed.
+
+#pragma once
+
+#include <mutex>
+
+#include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/storage/object_cache.hpp"
+#include "filesystem_ref_registry.hpp"
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Main per-instance state container
+// Inherits from ObjectCacheEntry for automatic cleanup when DatabaseInstance is destroyed
+//===--------------------------------------------------------------------===//
+struct ObservefsInstanceState : public ObjectCacheEntry {
+	static constexpr const char *OBJECT_TYPE = "ObservefsInstanceState";
+	static constexpr const char *CACHE_KEY = "observefs_instance_state";
+
+	ObservabilityFsRefRegistry registry;
+
+	ObservefsInstanceState() = default;
+
+	// ObjectCacheEntry interface
+	string GetObjectType() override {
+		return OBJECT_TYPE;
+	}
+
+	static string ObjectType() {
+		return OBJECT_TYPE;
+	}
+};
+
+//===--------------------------------------------------------------------===//
+// Helper functions to access instance state
+//===--------------------------------------------------------------------===//
+
+// Store instance state in the duckdb instance.
+void SetInstanceState(DatabaseInstance &instance, shared_ptr<ObservefsInstanceState> state);
+
+// Get instance state as shared_ptr from DatabaseInstance, and returns nullptr if not set.
+shared_ptr<ObservefsInstanceState> GetInstanceStateShared(DatabaseInstance &instance);
+
+// Get instance state, throwing if not found.
+ObservefsInstanceState &GetInstanceStateOrThrow(DatabaseInstance &instance);
+
+} // namespace duckdb

--- a/src/observefs_instance_state.cpp
+++ b/src/observefs_instance_state.cpp
@@ -1,0 +1,21 @@
+#include "observefs_instance_state.hpp"
+
+namespace duckdb {
+
+void SetInstanceState(DatabaseInstance &instance, shared_ptr<ObservefsInstanceState> state) {
+	instance.GetObjectCache().Put(ObservefsInstanceState::CACHE_KEY, std::move(state));
+}
+
+shared_ptr<ObservefsInstanceState> GetInstanceStateShared(DatabaseInstance &instance) {
+	return instance.GetObjectCache().Get<ObservefsInstanceState>(ObservefsInstanceState::CACHE_KEY);
+}
+
+ObservefsInstanceState &GetInstanceStateOrThrow(DatabaseInstance &instance) {
+	auto state = instance.GetObjectCache().Get<ObservefsInstanceState>(ObservefsInstanceState::CACHE_KEY);
+	if (state == nullptr) {
+		throw InternalException("observefs instance state not found - extension not properly loaded");
+	}
+	return *state;
+}
+
+} // namespace duckdb


### PR DESCRIPTION
Current filesystem registry is per-process, this PR makes it per-instance so we could have multiple duckdb instances in one single process.