### PR TITLE
Split constants to header and impl file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(EXTENSION_SOURCES
     src/filesystem_ref_registry.cpp
     src/filesystem_status_query_function.cpp
     src/histogram.cpp
+    src/io_operation.cpp
     src/metrics_collector.cpp
     src/numeric_utils.cpp
     src/observability_filesystem.cpp

--- a/src/include/io_operation.hpp
+++ b/src/include/io_operation.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 
 namespace duckdb {
@@ -21,10 +22,9 @@ enum class IoOperation {
 	kUnknown = 5,
 };
 
-inline constexpr auto kIoOperationCount = static_cast<size_t>(IoOperation::kUnknown);
+constexpr size_t kIoOperationCount = static_cast<size_t>(IoOperation::kUnknown);
 
 // Operation names, indexed by operation enums.
-inline constexpr std::array<const char *, kIoOperationCount> OPER_NAMES = {"open", "read", "list", "glob",
-                                                                           "get_file_size"};
+extern const std::array<const char *, kIoOperationCount> OPER_NAMES;
 
 } // namespace duckdb

--- a/src/include/operation_latency_collector.hpp
+++ b/src/include/operation_latency_collector.hpp
@@ -24,18 +24,7 @@ struct LatencyHeuristic {
 	int num_buckets;
 };
 
-inline constexpr std::array<LatencyHeuristic, static_cast<size_t>(IoOperation::kUnknown)> kLatencyHeuristics = {{
-    // kOpen
-    {0, 1000, 100},
-    // kRead
-    {0, 1000, 100},
-    // kList
-    {0, 3000, 100},
-    // kGlob
-    {0, 3000, 100},
-    // kGetFileSize,
-    {0, 1000, 100},
-}};
+extern const std::array<LatencyHeuristic, static_cast<size_t>(IoOperation::kUnknown)> kLatencyHeuristics;
 
 // A RAII guard to measure latency for IO operations.
 class LatencyGuard {

--- a/src/include/quantile.hpp
+++ b/src/include/quantile.hpp
@@ -40,7 +40,7 @@ private:
 	};
 
 	// P50, P75, P90, P95, P99
-	inline static constexpr size_t QUANTILE_COUNT = 5;
+	static constexpr size_t QUANTILE_COUNT = 5;
 	float q = 0;
 	int n = 0;
 	std::array<Marker, QUANTILE_COUNT> markers;

--- a/src/include/quantile_estimator.hpp
+++ b/src/include/quantile_estimator.hpp
@@ -39,7 +39,7 @@ private:
 	string quantile_unit;
 
 	// Used to trigger large-scale data point ingestion.
-	inline static constexpr size_t LARGE_SCALE_DATA_POINT_THRESHOLD = 512;
+	static constexpr size_t LARGE_SCALE_DATA_POINT_THRESHOLD = 512;
 	mutable std::mutex mu;
 	// Used for small scale data points, where P² algorithm doesn't work well and memory footprint is acceptable.
 	QuantileLite quantile_lite;

--- a/src/io_operation.cpp
+++ b/src/io_operation.cpp
@@ -1,0 +1,7 @@
+#include "io_operation.hpp"
+
+namespace duckdb {
+
+const std::array<const char *, kIoOperationCount> OPER_NAMES = {"open", "read", "list", "glob", "get_file_size"};
+
+} // namespace duckdb

--- a/src/operation_latency_collector.cpp
+++ b/src/operation_latency_collector.cpp
@@ -6,6 +6,19 @@
 
 namespace duckdb {
 
+const std::array<LatencyHeuristic, static_cast<size_t>(IoOperation::kUnknown)> kLatencyHeuristics = {{
+    // kOpen
+    {0, 1000, 100},
+    // kRead
+    {0, 1000, 100},
+    // kList
+    {0, 3000, 100},
+    // kGlob
+    {0, 3000, 100},
+    // kGetFileSize,
+    {0, 1000, 100},
+}};
+
 namespace {
 const NoDestructor<string> LATENCY_HISTOGRAM_ITEM {"latency"};
 const NoDestructor<string> LATENCY_HISTOGRAM_UNIT {"millisec"};


### PR DESCRIPTION
The current implementation doesn't work for MSVC.