### PR TITLE
Fix httpfs compatibility and null handle

### DIFF
--- a/src/observability_filesystem.cpp
+++ b/src/observability_filesystem.cpp
@@ -40,6 +40,9 @@ unique_ptr<FileHandle> ObservabilityFileSystem::OpenFile(const string &path, Fil
                                                          optional_ptr<FileOpener> opener) {
 	const auto latency_guard = metrics_collector.RecordOperationStart(IoOperation::kOpen, path);
 	auto file_handle = internal_filesystem->OpenFile(path, flags, opener);
+	if (!file_handle) {
+		return nullptr;
+	}
 	return make_uniq<ObservabilityFileSystemHandle>(std::move(file_handle), *this);
 }
 int64_t ObservabilityFileSystem::GetFileSize(FileHandle &handle) {

--- a/test/sql/attach_db.test
+++ b/test/sql/attach_db.test
@@ -1,0 +1,13 @@
+# name: test/sql/attach_db.test
+# description: test database file attachment
+# group: [sql]
+
+require observefs
+
+statement ok
+ATTACH 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/sample.duckdb' as db;
+
+query III
+SELECT database_name, schema_name, table_name FROM duckdb_tables() WHERE database_name = 'db';
+----
+db	main	users


### PR DESCRIPTION
This PR fixes two issues:
- Ensure compatibility with httpfs extension, so users could attach remote database files
- When internal filesystem doesn't open a file (which returns null on open), propagate it up instead of creating file handle wrapper

The added unit tests checks both of them.